### PR TITLE
fix(brew): rename the Zoom cask

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -61,7 +61,7 @@ cask "rectangle"
 cask "slack"
 cask "spotify"
 cask "xmind-zen"
-cask "zoomus"
+cask "zoom"
 
 # App Store
 mas "Drafts", id: 1435957248


### PR DESCRIPTION
It has been renamed from zoomus to zoom.