### PR TITLE
feat(git): use diff3 as global conflict style

### DIFF
--- a/gitconfig.user
+++ b/gitconfig.user
@@ -50,6 +50,7 @@
 [init]
 	defaultBranch = main
 [merge]
+	conflictStyle = diff3
 	ff = only
 [mergetool]
 	keepBackup = false


### PR DESCRIPTION
This makes it easier to resolve merge conflicts by providing a base
commit that can be used as a reference point.