### PR TITLE
fix(rcm): exclude node_modules and package.json lockfiles from rcup

### DIFF
--- a/rcrc
+++ b/rcrc
@@ -1,2 +1,2 @@
 EXCLUDES="README*.md LICENSE.md install.sh tags Brewfile bin Brewfile*
-          lint-*.sh requirements"
+          lint-*.sh requirements node_modules package.json package-lock.json"


### PR DESCRIPTION
Prevents `rcup` from copying these files to the $HOME directory.