### PR TITLE
feat(bash): create bash_completion directory

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+for bcfile in ~/.bash_completion.d/*; do
+  # shellcheck disable=SC1090
+  [ -f "$bcfile" ] && . "$bcfile"
+done
+unset -v bcfile

--- a/bashrc.d/completion.bash
+++ b/bashrc.d/completion.bash
@@ -1,3 +1,3 @@
 # Bash completion.
-# shellcheck disable=SC1091
-[[ -r "/usr/local/etc/profile.d/bash_completion.sh" ]] && . "/usr/local/etc/profile.d/bash_completion.sh"
+# shellcheck source=/dev/null
+[[ -r "$(brew --prefix)/etc/profile.d/bash_completion.sh" ]] && . "$(brew --prefix)/etc/profile.d/bash_completion.sh"


### PR DESCRIPTION
Allow setting custom bash completion scripts in dotfiles.

Also use brew prefix for bash_completion script.