### PR TITLE
Remove vim generated files from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,3 @@
 *.log
 node_modules/
 Brewfile*.lock.json
-
-vim/.vim/backups/
-vim/.vim/pack/
-vim/.vim/viminfo


### PR DESCRIPTION
These are now being stored in XDG_CACHE directories.