### PR TITLE
feat(bin): add git-remove-merged-local script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 Brewfile*.lock.json
 
 # Ignore generated files
+bin/git-remove-merged-local
 bin/git-stats-loc
 git/config

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ XDG_STATE_HOME ?= $(HOME)/.local/state
 
 NAME ?= 'Dylan Pinn'
 
-BINS = bin/git-stats-loc
+BINS = bin/git-remove-merged-local \
+       bin/git-stats-loc
 
 all: $(BINS) \
 	git/config

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,9 @@ clean-bash :
 	rm -f -- $(HOME)/.bash_profile
 	rm -rf -- $(HOME)/.bashrc.d
 
+clean-bin:
+	rm -r -- $(HOME)/.local/bin
+
 clean-emacs :
 	rm -f -- $(XDG_CONFIG_HOME)/emacs/init.el
 
@@ -85,7 +88,7 @@ install-bash : check-bash clean-bash install-sh
 	ln -s -- $(PWD)/bash/bash_profile $(HOME)/.bash_profile
 	ln -s -- $(PWD)/bash/bashrc.d/* $(HOME)/.bashrc.d/
 
-install-bin: $(BINS)
+install-bin: $(BINS) clean-bin
 	mkdir -p -- $(HOME)/.local/bin
 	install -- $(BINS) $(HOME)/.local/bin/
 

--- a/bin/git-remove-merged-local.sh
+++ b/bin/git-remove-merged-local.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+#
+# Remove merged local branches in a Git repo.
+#
+
+set -eou pipefail
+
+git fetch -p && for branch in $(git branch -vv | grep ': gone]' | awk '{print $1}'); do git branch -D "$branch"; done


### PR DESCRIPTION
Remove all old merged local branches that are no longer present on the
remote.

Taken from
https://stackoverflow.com/questions/7726949/remove-tracking-branches-no-longer-on-remote.