### PR TITLE
chore/remove symlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 Brewfile*.lock.json
 
 # Ignore generated files
+bin/git-stats-loc
 git/config

--- a/Makefile
+++ b/Makefile
@@ -5,14 +5,12 @@ XDG_DATA_HOME ?= $(HOME)/.local/share
 XDG_STATE_HOME ?= $(HOME)/.local/state
 
 NAME ?= 'Dylan Pinn'
-EMAIL ?= 'me@dylanpinn.com'
 
 all: git/config
 
 git/config: git/config.m4
 	m4 \
 		-D NAME=$(NAME) \
-		-D EMAIL=$(EMAIL) \
 		git/config.m4 > $@
 
 install : install-bash \

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,14 @@ XDG_STATE_HOME ?= $(HOME)/.local/state
 NAME ?= 'Dylan Pinn'
 EMAIL ?= 'me@dylanpinn.com'
 
+all: git/config
+
+git/config: git/config.m4
+	m4 \
+		-D NAME=$(NAME) \
+		-D EMAIL=$(EMAIL) \
+		git/config.m4 > $@
+
 install : install-bash \
 	install-bin \
 	install-git \
@@ -61,12 +69,6 @@ format-lua:
 
 format-sh:
 	sh format/sh.sh
-
-git/config: git/config.m4
-	m4 \
-		-D NAME=$(NAME) \
-		-D EMAIL=$(EMAIL) \
-		git/config.m4 > $@
 
 install-aws : install-sh
 	ln -s -- $(PWD)/aws/profile.d/* $(HOME)/.profile.d/

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,10 @@ XDG_STATE_HOME ?= $(HOME)/.local/state
 
 NAME ?= 'Dylan Pinn'
 
-all: git/config
+BINS = bin/git-stats-loc
+
+all: $(BINS) \
+	git/config
 
 git/config: git/config.m4
 	m4 \
@@ -29,13 +32,15 @@ check-bash :
 check-sh :
 	sh check/sh.sh
 
+clean:
+	rm -r -- \
+		$(BINS) \
+		git/config
+
 clean-bash :
 	rm -f -- $(HOME)/.bashrc
 	rm -f -- $(HOME)/.bash_profile
 	rm -rf -- $(HOME)/.bashrc.d
-
-clean-bin:
-	rm -rf -- $(HOME)/.local/bin
 
 clean-emacs :
 	rm -f -- $(XDG_CONFIG_HOME)/emacs/init.el
@@ -79,9 +84,9 @@ install-bash : check-bash clean-bash install-sh
 	ln -s -- $(PWD)/bash/bash_profile $(HOME)/.bash_profile
 	ln -s -- $(PWD)/bash/bashrc.d/* $(HOME)/.bashrc.d/
 
-install-bin: clean-bin
+install-bin: $(BINS)
 	mkdir -p -- $(HOME)/.local/bin
-	ln -s -- $(PWD)/bin/* $(HOME)/.local/bin/
+	install -- $(BINS) $(HOME)/.local/bin/
 
 install-brew :
 	brew update

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+.POSIX:
 XDG_CACHE_HOME ?= $(HOME)/.cache
 XDG_CONFIG_HOME ?= $(HOME)/.config
 XDG_DATA_HOME ?= $(HOME)/.local/share

--- a/bin/git-stats-loc.sh
+++ b/bin/git-stats-loc.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+#
+# Print LOC for each commit of the Git repo.
+# Output
+# LOC SHA Commit Message
+
+set -e
+
+file_pattern=$1
+
+main() {
+  for rev in $(revisions); do
+    echo "$(number_of_lines) $(commit_description)"
+  done
+}
+
+revisions() {
+  git rev-list --reverse HEAD
+}
+
+commit_description() {
+  git log --oneline -1 "$rev"
+}
+
+number_of_lines() {
+  git ls-tree -r "$rev" \
+    | grep "$file_pattern" \
+    | awk '{ print $3 }' \
+    | xargs git show \
+    | wc -l
+}
+
+main

--- a/check/sh.sh
+++ b/check/sh.sh
@@ -2,9 +2,15 @@
 #
 # Check syntax for sh files.
 
-for sh in sh/* */profile.d/*; do
-  [ -f "$sh" ] || continue
-  sh -n -- "$sh"
+set -e
+
+set sh/profile
+
+sh -n -- "$@"
+
+find . -type f -name "*.sh" | while IFS='' read -r line; do
+  [ -f "$line" ] || continue
+  sh -n -- "$line"
 done
 
 printf 'POSIX shell scripts parsed successfully.\n'

--- a/git/config.m4
+++ b/git/config.m4
@@ -51,4 +51,3 @@
 	autosquash = true
 [user]
 	name = NAME
-	email = EMAIL

--- a/personal/profile.d/email.sh
+++ b/personal/profile.d/email.sh
@@ -1,0 +1,2 @@
+# Set EMAIL that git will use
+export EMAIL="me@dylanpinn.com"

--- a/work/profile.d/email.sh
+++ b/work/profile.d/email.sh
@@ -1,0 +1,2 @@
+# Set EMAIL that git will use
+export EMAIL="dylan.pinn@rea-group.com"


### PR DESCRIPTION
* chore(sh): fix check script to search for all sh files

* chore(bin): use file extension for all bin scripts
    
    This makes linting and formatting easier and make will remove the
    extension and set correct permissions.

* chore(git): use EMAIL rather than user.email for git config

* chore(make): set POSIX for Makefile
    
    This will ensure that it should work with all flavours of make.

* refactor(make): move non phony targets to top
