### PR TITLE
fix(vim): improve git repo detection for git-grep

### DIFF
--- a/vim/plugin/git-grep.vim
+++ b/vim/plugin/git-grep.vim
@@ -1,7 +1,8 @@
 " Check if .git directory in current root.  If so then use git-grep as
 " grepprg.
 function! SetGitGrep()
-  if isdirectory('.git')
+  silent! !git rev-parse --is-inside-work-tree &>/dev/null
+  if v:shell_error == 0
     setlocal grepprg=git\ grep\ -n\ $*
   endif
 endfunction


### PR DESCRIPTION
Use git to check if we are currently in a repo to determine if vim
should be using git grep over grep.  This fixes an issue where git-grep
would only be set if vim was opened in the project root without opening
any files or other directories, i.e. `vim` or `vim .`.
