### PR TITLE
chore(commitlint): ignore Dependabot commits

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,4 @@
-module.exports = {extends: ['@commitlint/config-conventional']}
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  ignores: [(message) => /^Bumps \[(.+)\]\((.+)\)(.*).$/m.test(message)],
+}


### PR DESCRIPTION
Dependabot commit messages often fail commitlint rules especially
regarding line length <= 100.
