### PR TITLE
feat(nvim): use ripgrep instead of grep

### DIFF
--- a/nvim/lua/dcp/options.lua
+++ b/nvim/lua/dcp/options.lua
@@ -8,6 +8,11 @@ vim.opt.define = ""
 vim.opt.include = ""
 vim.opt.path:remove({ "/usr/include" })
 
+-- Use ripgrep for searching files rather than grep(1).
+-- rg is faster and automatically excludes ignored files.
+vim.opt.grepprg = "rg --vimgrep --no-heading --smart-case"
+vim.opt.grepformat:prepend({ "%f:%l:%c:%m" })
+
 -- Configure the wildmenu to ignore a list of patterns for file and directory
 -- command line completion.  Files and directories matching any of these
 -- patterns won't be presented as candidates for tab completion on the command


### PR DESCRIPTION
Improve the built-in text searching for Neovim by using ripgrep.  This
gives faster searching time and automatically excludes ignored files by
default.
