### PR TITLE
fix(nvim): add guard check for ripgrep integration

### DIFF
--- a/nvim/lua/dcp/options.lua
+++ b/nvim/lua/dcp/options.lua
@@ -10,8 +10,10 @@ vim.opt.path:remove({ "/usr/include" })
 
 -- Use ripgrep for searching files rather than grep(1).
 -- rg is faster and automatically excludes ignored files.
-vim.opt.grepprg = "rg --vimgrep --no-heading --smart-case"
-vim.opt.grepformat:prepend({ "%f:%l:%c:%m" })
+if vim.fn.executable("rg") == 1 then
+  vim.opt.grepprg = "rg --vimgrep --no-heading --smart-case"
+  vim.opt.grepformat:prepend({ "%f:%l:%c:%m" })
+end
 
 -- Use basic statusline, using this rather than an external plugin to do this as this currently fits my needs and
 -- doesn't add extra complexity.


### PR DESCRIPTION
Only use `rg` to replace `grep(1)` if it is executable. This will
prevent errors for systems where it hasn't been installed yet.
