### PR TITLE
feat(homebrew): remove Figma from work apps

### DIFF
--- a/homebrew/Brewfile-work
+++ b/homebrew/Brewfile-work
@@ -70,8 +70,6 @@ cask "canon-ijscanner13f"
 cask "dash"
 # App to build and share containerized applications and microservices
 cask "docker"
-# Collaborative team software
-cask "figma"
 # Web browser
 cask "firefox"
 # Typeface made for developers


### PR DESCRIPTION
Going to try to focus on using it in the browser fulltime now that
I have shifted over to using Firefox as my default browser rather than
Safari.
