### PR TITLE
feat(nvim): use 2 spaces for markdown indent

### DIFF
--- a/nvim/indent/markdown.lua
+++ b/nvim/indent/markdown.lua
@@ -1,0 +1,4 @@
+-- Use 2 spaces for indentation, per convention.
+vim.opt_local.expandtab = true
+vim.opt_local.shiftwidth = 2
+vim.opt_local.softtabstop = 2


### PR DESCRIPTION
Set this explicitly rather than the default of an 8 spaced tab.
