### PR TITLE
fix(nivm): automatic setup is now handled by mason-null-ls

### DIFF
--- a/nvim/after/plugin/lsp.lua
+++ b/nvim/after/plugin/lsp.lua
@@ -91,15 +91,6 @@ require("null-ls").setup({
   },
 })
 
-require("mason-null-ls").setup_handlers({
-  function(source_name, methods)
-    -- all sources with no handler get passed here
-
-    -- To keep the original functionality of `automatic_setup = true`,
-    -- please add the below.
-    require("mason-null-ls.automatic_setup")(source_name, methods)
-  end,
-  stylua = function(_, _)
-    null_ls.register(null_ls.builtins.formatting.stylua)
-  end,
+require("mason-null-ls").setup({
+  automatic_setup = true,
 })

--- a/nvim/after/plugin/lsp.lua
+++ b/nvim/after/plugin/lsp.lua
@@ -1,6 +1,5 @@
 require("mason").setup()
 require("mason-lspconfig").setup()
-local null_ls = require("null-ls")
 
 -- Use an on_attach function to only map the following keys
 -- after the language server attaches to the current buffer


### PR DESCRIPTION
Manually setting up the setup-handlers is no longer required by
mason-null-ls v2.

Ref: https://github.com/jay-babu/mason-null-ls.nvim/releases/tag/v2.0.0
