### PR TITLE
feat(work): add Pocket Casts to Homebrew apps

### DIFF
--- a/homebrew/Brewfile-work
+++ b/homebrew/Brewfile-work
@@ -96,6 +96,8 @@ cask "logseq"
 cask "loom"
 # Web browser
 cask "microsoft-edge"
+# Podcast platform
+cask "pocket-casts"
 # Control your tools with a few keystrokes
 cask "raycast"
 # Move and resize windows using keyboard shortcuts or snap areas


### PR DESCRIPTION
Using this now (again) instead of the Apple Podcasts.app.
