### PR TITLE
feat(asdf): setup asdf to use Java

### DIFF
--- a/asdf/asdfrc
+++ b/asdf/asdfrc
@@ -1,1 +1,2 @@
+java_macos_integration_enable = yes
 legacy_version_file = yes

--- a/asdf/bashrc.d/asdf.bash
+++ b/asdf/bashrc.d/asdf.bash
@@ -1,2 +1,5 @@
 # Setup ASDF
 . "$(brew --prefix asdf)"/libexec/asdf.sh
+
+# Setup ASDF Java
+. "$XDG_DATA_HOME"/asdf/plugins/java/set-java-home.bash


### PR DESCRIPTION
Set the JAVA_HOME environment variable when setting Java versions using
asdf. Also, use the macOS integration in `/usr/libexec/java_home` for
some applications.
