### PR TITLE
feat(nvim): change LSP keybindings to use autocommand

### DIFF
--- a/nvim/after/plugin/lsp.lua
+++ b/nvim/after/plugin/lsp.lua
@@ -1,41 +1,43 @@
 require("mason").setup()
 require("mason-lspconfig").setup()
 
--- Use an on_attach function to only map the following keys
+-- Global mappings.
+-- See `:help vim.diagnostic.*` for documentation on any of the below functions
+vim.keymap.set('n', '<localleader>e', vim.diagnostic.open_float)
+vim.keymap.set('n', '[d', vim.diagnostic.goto_prev)
+vim.keymap.set('n', ']d', vim.diagnostic.goto_next)
+vim.keymap.set('n', '<localleader>q', vim.diagnostic.setloclist)
+
+-- Use LspAttach autocommand to only map the following keys
 -- after the language server attaches to the current buffer
-local on_attach = function(_, bufnr)
-  -- Mappings.
-  -- See `:help vim.diagnostic.*` for documentation on any of the below functions
-  local opts = { noremap = true, silent = true }
-  vim.keymap.set("n", "<localleader>e", vim.diagnostic.open_float, opts)
-  vim.keymap.set("n", "[d", vim.diagnostic.goto_prev, opts)
-  vim.keymap.set("n", "]d", vim.diagnostic.goto_next, opts)
-  vim.keymap.set("n", "<localleader>q", vim.diagnostic.setloclist, opts)
+vim.api.nvim_create_autocmd('LspAttach', {
+  group = vim.api.nvim_create_augroup('UserLspConfig', {}),
+  callback = function(ev)
+    -- Enable completion triggered by <c-x><c-o>
+    vim.bo[ev.buf].omnifunc = 'v:lua.vim.lsp.omnifunc'
 
-  -- Enable completion triggered by <c-x><c-o>
-  vim.api.nvim_buf_set_option(bufnr, "omnifunc", "v:lua.vim.lsp.omnifunc")
-
-  -- Mappings.
-  -- See `:help vim.lsp.*` for documentation on any of the below functions
-  local bufopts = { noremap = true, silent = true, buffer = bufnr }
-  vim.keymap.set("n", "gD", vim.lsp.buf.declaration, bufopts)
-  vim.keymap.set("n", "gd", vim.lsp.buf.definition, bufopts)
-  vim.keymap.set("n", "K", vim.lsp.buf.hover, bufopts)
-  vim.keymap.set("n", "gi", vim.lsp.buf.implementation, bufopts)
-  vim.keymap.set("n", "<C-k>", vim.lsp.buf.signature_help, bufopts)
-  vim.keymap.set("n", "<localleader>wa", vim.lsp.buf.add_workspace_folder, bufopts)
-  vim.keymap.set("n", "<localleader>wr", vim.lsp.buf.remove_workspace_folder, bufopts)
-  vim.keymap.set("n", "<localleader>wl", function()
-    print(vim.inspect(vim.lsp.buf.list_workspace_folders()))
-  end, bufopts)
-  vim.keymap.set("n", "<localleader>D", vim.lsp.buf.type_definition, bufopts)
-  vim.keymap.set("n", "<localleader>rn", vim.lsp.buf.rename, bufopts)
-  vim.keymap.set("n", "<localleader>ca", vim.lsp.buf.code_action, bufopts)
-  vim.keymap.set("n", "gr", vim.lsp.buf.references, bufopts)
-  vim.keymap.set("n", "<localleader>f", function()
-    vim.lsp.buf.format({ async = true })
-  end, bufopts)
-end
+    -- Buffer local mappings.
+    -- See `:help vim.lsp.*` for documentation on any of the below functions
+    local opts = { buffer = ev.buf }
+    vim.keymap.set('n', 'gD', vim.lsp.buf.declaration, opts)
+    vim.keymap.set('n', 'gd', vim.lsp.buf.definition, opts)
+    vim.keymap.set('n', 'K', vim.lsp.buf.hover, opts)
+    vim.keymap.set('n', 'gi', vim.lsp.buf.implementation, opts)
+    vim.keymap.set('n', '<C-k>', vim.lsp.buf.signature_help, opts)
+    vim.keymap.set('n', '<localleader>wa', vim.lsp.buf.add_workspace_folder, opts)
+    vim.keymap.set('n', '<localleader>wr', vim.lsp.buf.remove_workspace_folder, opts)
+    vim.keymap.set('n', '<localleader>wl', function()
+      print(vim.inspect(vim.lsp.buf.list_workspace_folders()))
+    end, opts)
+    vim.keymap.set('n', '<localleader>D', vim.lsp.buf.type_definition, opts)
+    vim.keymap.set('n', '<localleader>rn', vim.lsp.buf.rename, opts)
+    vim.keymap.set({ 'n', 'v' }, '<localleader>ca', vim.lsp.buf.code_action, opts)
+    vim.keymap.set('n', 'gr', vim.lsp.buf.references, opts)
+    vim.keymap.set('n', '<localleader>f', function()
+      vim.lsp.buf.format { async = true }
+    end, opts)
+  end,
+})
 
 -- Automatically setup LSP servers using mason-lspconfig.
 require("mason-lspconfig").setup_handlers({
@@ -44,13 +46,11 @@ require("mason-lspconfig").setup_handlers({
   -- a dedicated handler.
   function(server_name) -- default handler (optional)
     require("lspconfig")[server_name].setup({
-      on_attach = on_attach,
     })
   end,
   -- Lua LS requires additional configuration.
   ["lua_ls"] = function()
     require("lspconfig").lua_ls.setup({
-      on_attach = on_attach,
       settings = {
         Lua = {
           runtime = {


### PR DESCRIPTION
This is now the suggested approach in the nvim-lspconfig repository (1),
so changing from on_attach to use native vim autocommands.

Also moving some of the diagnostic key-bindings out to be global,
should fix up problems where trying to diagnostic checks using other LSP
functions that are not related to a LSP such as linters.

Ref(1): https://github.com/neovim/nvim-lspconfig#suggested-configuration
