### PR TITLE
feat(work): remove bash-my-aws configuration

### DIFF
--- a/work/bashrc.d/bash-my-aws.bash
+++ b/work/bashrc.d/bash-my-aws.bash
@@ -1,3 +1,0 @@
-# Enable Bash my AWS
-export PATH="$PATH:$HOME/.bash-my-aws/bin"
-source ~/.bash-my-aws/aliases


### PR DESCRIPTION
Trying to use native aws-cli commands rather than this collection of
shortcuts.
