### PR TITLE
feat(work): use Google Authenticator for MFA challenges

### DIFF
--- a/work/profile.d/rea-as.sh
+++ b/work/profile.d/rea-as.sh
@@ -1,0 +1,2 @@
+# Use Google Authenticator for MFA method.
+export REA_AS_MFA_METHOD=GOOGLE_AUTHENTICATOR


### PR DESCRIPTION
Reather than using Okta's implementation, use the MFA token from Google
Authenticator.
