### PR TITLE
feat(nvim): add configuration for ltex-ls

### DIFF
--- a/nvim/after/plugin/lsp.lua
+++ b/nvim/after/plugin/lsp.lua
@@ -74,6 +74,17 @@ require("mason-lspconfig").setup_handlers({
       },
     })
   end,
+  -- ltex-ls requires additional configuration.
+  ["ltex"] = function()
+    require('lspconfig').ltex.setup({
+      settings = {
+        ltex = {
+          language = "en-AU",
+          languageToolHttpServerUri = "http://localhost:8081/"
+        }
+      },
+    })
+  end,
 })
 
 require("mason-null-ls").setup({


### PR DESCRIPTION
This allows me to use a local instance of LanguageTool to check
spelling and grammar for text, and text like files.
