### PR TITLE
feat(nvim): enable experimental lua loader

### DIFF
--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -3,6 +3,9 @@
 -- It is intentionally very bare bones and using the features of Neovim that
 -- are missing from Vim, i.e. LSP and treesitter.
 
+-- Enable experimental lua-loader to byte-compile and cache lua files.
+vim.loader.enable()
+
 -- The configuration is located in the dcp module (located in the lua
 -- directory). It is then split up based on the type of configuration to make
 -- small files rather than a single large file (vimrc).


### PR DESCRIPTION
This should speed up Neovim loading time by utilising caching and
byte-compilation of lua files.

This will be enabled by default in a future release, so trying it now
for a while to experiement.
