### PR TITLE
fix(alacritty): fix symbolic link creation when installing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,8 @@ format-sh:
 	sh format/sh.sh
 
 install-alacritty:
-	ln -sf -- $(PWD)/alacritty $(XDG_CONFIG_HOME)/alacritty
+	mkdir -p -- $(XDG_CONFIG_HOME)/alacritty
+	ln -sf -- $(PWD)/alacritty/* $(XDG_CONFIG_HOME)/alacritty/
 
 install-asdf: install-bash
 	install -- $(PWD)/asdf/bashrc.d/* $(HOME)/.bashrc.d/


### PR DESCRIPTION
Previously it was creating symbolic links in the dotfiles directory,
this fixes this and works correctly and allows re-running the command.
