### PR TITLE
fix(work): temp remove mas upgrade from update_machine

### DIFF
--- a/work/profile.d/update-machine.sh
+++ b/work/profile.d/update-machine.sh
@@ -4,5 +4,5 @@ update_machine () {
   brew upgrade --cask
   rea --disable-auto-update cli update
   asdf plugin-update --all
-  mas upgrade
+  # mas upgrade
 }


### PR DESCRIPTION
This is causing issues and it is not completing. Will add back in the
future.
