### PR TITLE
feat(git): reverse order of git-changelog

### DIFF
--- a/home/private_dot_config/git/config.tmpl
+++ b/home/private_dot_config/git/config.tmpl
@@ -17,7 +17,7 @@
 	dc = diff --cached
 
 	# Log
-	changelog = log origin..HEAD --format='* %s%n%w(,4,4)%+b'
+	changelog = log --reverse origin..HEAD --format='* %s%n%w(,4,4)%+b'
 	glg = log --oneline --decorate --all --graph --abbrev-commit
 
 	# Pull


### PR DESCRIPTION
This now more matches what should be expected which is the list of
commits in order from least to most recent.
