### PR TITLE
nvim: move luacheck into compiler plugin

### DIFF
--- a/home/.Brewfile_work
+++ b/home/.Brewfile_work
@@ -54,8 +54,6 @@ brew "shellcheck"
 brew "stow"
 # Opinionated Lua code formatter
 brew "stylua"
-# Simplified and community-driven man pages
-brew "tldr"
 # Terminal multiplexer
 brew "tmux"
 # Vi 'workalike' with many additional features

--- a/home/.Brewfile_work
+++ b/home/.Brewfile_work
@@ -40,8 +40,6 @@ brew "htop"
 brew "jq"
 # JIT library for the GNU compiler collection
 brew "libgccjit"
-# Tool for linting and static analysis of Lua code
-brew "luacheck"
 # Package manager for the Lua programming language
 brew "luarocks"
 # Mac App Store command-line interface

--- a/home/.chezmoiscripts/run_onchange_before_setup-development-tools.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_before_setup-development-tools.sh.tmpl
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+{{ if eq .chezmoi.hostname "C02FJ1QSQ05P" -}}
+# Required for Lua development or using Neovim.
+# Setup luacheck (lua linter).
+luarocks install luacheck
+luarocks install lanes
+{{- end -}}
+

--- a/home/private_dot_config/nvim/after/plugin/lsp.lua
+++ b/home/private_dot_config/nvim/after/plugin/lsp.lua
@@ -88,7 +88,6 @@ require("mason-lspconfig").setup_handlers({
 
 require("mason-null-ls").setup({
   ensure_installed = {
-    "luacheck",
     "stylua",
   },
   automatic_installation = false,

--- a/home/private_dot_config/nvim/compiler/luacheck.vim
+++ b/home/private_dot_config/nvim/compiler/luacheck.vim
@@ -1,0 +1,21 @@
+" Vim compiler file
+" Compiler: luacheck
+" Author: Sean Dewar <https://github.com/seandewar>
+
+if exists('g:current_compiler')
+    finish
+endif
+let g:current_compiler = 'luacheck'
+
+let s:save_cpo = &cpoptions
+set cpoptions&vim
+
+if exists(':CompilerSet') != 2 " older Vim always used :setlocal
+  command -nargs=* CompilerSet setlocal <args>
+endif
+
+CompilerSet makeprg=luacheck\ --no-color
+CompilerSet errorformat=%f:%l:%c:\ %m,%-G%.%#
+
+let &cpoptions = s:save_cpo
+unlet s:save_cpo

--- a/lint/lua.sh
+++ b/lint/lua.sh
@@ -4,4 +4,4 @@
 
 set -e
 
-luacheck .luacheckrc
+luacheck .luacheckrc home


### PR DESCRIPTION
* fix: remove luacheck from homebrew and Mason defaults

* feat(brew): remove tldr
    
    No longer used.

* build: run lua linting over home directory
    
    This now contains all my Neovim lua config.

* feat(nvim): add luacheck as compiler plugin
    
    Can be used with :compiler luacheck.

* feat(chezmoi): setup lua development tools
    
    Setup luacheck via chezmoi if on work laptop.