### PR TITLE
nvim/stylua

### DIFF
--- a/format/lua.sh
+++ b/format/lua.sh
@@ -4,4 +4,4 @@
 
 set -e
 
-stylua .luacheckrc nvim/
+stylua .luacheckrc home/

--- a/home/private_dot_config/nvim/after/ftplugin/lua.lua
+++ b/home/private_dot_config/nvim/after/ftplugin/lua.lua
@@ -1,2 +1,7 @@
 -- Set maximum text width to 120 chars.
 vim.opt_local.textwidth = 120
+
+-- Use stylua as formatter if it is available.
+if vim.fn.executable("stylua") == 1 then
+  vim.opt_local.formatprg = "stylua --stdin-filepath % --search-parent-directories -"
+end

--- a/home/private_dot_config/nvim/after/plugin/lsp.lua
+++ b/home/private_dot_config/nvim/after/plugin/lsp.lua
@@ -87,9 +87,7 @@ require("mason-lspconfig").setup_handlers({
 })
 
 require("mason-null-ls").setup({
-  ensure_installed = {
-    "stylua",
-  },
+  ensure_installed = {},
   automatic_installation = false,
   automatic_setup = true, -- Recommended, but optional
   handlers = {},

--- a/home/private_dot_config/nvim/lua/dcp/options.lua
+++ b/home/private_dot_config/nvim/lua/dcp/options.lua
@@ -116,7 +116,6 @@ vim.opt.statusline = "%F%m%r%h%w[%L][%{&ff}]%y[%p%%][%04l,%04v]"
 --
 vim.opt.undofile = true
 
-
 -- Configure the wildmenu to ignore a list of patterns for file and directory
 -- command line completion.  Files and directories matching any of these
 -- patterns won't be presented as candidates for tab completion on the command


### PR DESCRIPTION
* fix(format): run lua formatter over home
    
    This is where Neovim configuration is now located.

* feat(nvim): stop requiring stylua is installed via Mason
    
    This will be now handled via external formatter.

* feat(nvim): setup stylua as formatprg for lua
    
    This will help to remove an extra dependency from Mason and null-ls.