### PR TITLE
feat(nvim): add vim-dispatch plugin

### DIFF
--- a/home/private_dot_config/nvim/lua/dcp/packages.lua
+++ b/home/private_dot_config/nvim/lua/dcp/packages.lua
@@ -15,8 +15,9 @@ return require("paq")({
   },
 
   -- Enhance (n)vim.
-  "tpope/vim-surround",
+  "tpope/vim-dispatch",
   "tpope/vim-repeat",
+  "tpope/vim-surround",
 
   -- LSP configuration; this makes configuring LSP servers easier.
   "neovim/nvim-lspconfig",


### PR DESCRIPTION
This makes working with `:make` a whole lot easier.

`:Make` will now use some smarts to either open a new tmux split or
another window.

`:Make!` can be used for long running tasks such as test suite or other
background jobs.

Reference: https://github.com/tpope/vim-dispatch
