### PR TITLE
work/update config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ git/config
 
 # Ignore package management
 node_modules
+
+# Ignore 1Password CLI config
+/.op/

--- a/home/.Brewfile_work
+++ b/home/.Brewfile_work
@@ -93,8 +93,6 @@ cask "jetbrains-toolbox"
 cask "logi-options-plus"
 # Optimize your webcam, headset, and Logi Dock for video meetings
 cask "logitune"
-# Privacy-first, open-source platform for knowledge sharing and management
-cask "logseq"
 # Screen and video recording software
 cask "loom"
 # Provides updates to various Microsoft products

--- a/home/.Brewfile_work
+++ b/home/.Brewfile_work
@@ -11,6 +11,8 @@ brew "bash"
 brew "bash-completion@2"
 # Manage your dotfiles across multiple diverse machines, securely
 brew "chezmoi"
+# Docker Credential Helper for Amazon ECR
+brew "docker-credential-helper-ecr"
 # GitHub command-line tool
 brew "gh"
 # Distributed revision control system
@@ -25,6 +27,8 @@ brew "luarocks"
 brew "mas"
 # Ambitious Vim-fork focused on extensibility and agility
 brew "neovim"
+# Search tool like grep and The Silver Searcher
+brew "ripgrep"
 # Encrypt and decrypt secrets using the AWS Key Management Service
 brew "shush"
 # Organize software neatly under a single directory tree (e.g. /usr/local)

--- a/home/.Brewfile_work
+++ b/home/.Brewfile_work
@@ -65,6 +65,8 @@ cask "appcleaner"
 cask "arc"
 # Menu bar icon organizer
 cask "bartender"
+# Record and process your ideas
+cask "bike"
 # Screen capturing tool
 cask "cleanshot"
 # App to build and share containerized applications and microservices

--- a/home/.Brewfile_work
+++ b/home/.Brewfile_work
@@ -1,6 +1,8 @@
 tap "homebrew/bundle"
 tap "homebrew/cask-fonts"
 tap "reainternal/stable", "git@git.realestate.com.au:cowbell/homebrew-stuff"
+# Mozilla CA certificate store
+brew "ca-certificates"
 # Extendable version manager with support for Ruby, Node.js, Erlang & more
 brew "asdf"
 # Official Amazon AWS command-line interface
@@ -25,6 +27,8 @@ brew "hadolint"
 brew "htop"
 # Lightweight and flexible command-line JSON processor
 brew "jq"
+# Postgres C API library
+brew "libpq", link: true
 # Package manager for the Lua programming language
 brew "luarocks"
 # Mac App Store command-line interface
@@ -140,6 +144,7 @@ cask "soundsource"
 # Video communication and virtual meeting platform
 cask "zoom"
 mas "1Password for Safari", id: 1569813296
+mas "Agenda", id: 1287445660
 mas "Bear", id: 1091189122
 mas "Dato", id: 1470584107
 mas "Display Menu", id: 549083868
@@ -154,6 +159,7 @@ mas "NepTunes", id: 1006739057
 mas "Numbers", id: 409203825
 mas "OpenIn", id: 1643649331
 mas "Parcel", id: 639968404
+mas "Save to Reader", id: 1640236961
 mas "Subscriptions", id: 1577082754
 mas "Things", id: 904280696
 mas "Velja", id: 1607635845

--- a/home/.Brewfile_work
+++ b/home/.Brewfile_work
@@ -1,23 +1,8 @@
-tap "ankitpokhrel/jira-cli"
-tap "d12frosted/emacs-plus"
 tap "homebrew/bundle"
 tap "homebrew/cask-fonts"
-tap "homebrew/services"
 tap "reainternal/stable", "git@git.realestate.com.au:cowbell/homebrew-stuff"
-# Mozilla CA certificate store
-brew "ca-certificates"
-# GNU multiple precision arithmetic library
-brew "gmp"
-# YAML Parser
-brew "libyaml"
-# Library for command-line editing
-brew "readline"
 # Extendable version manager with support for Ruby, Node.js, Erlang & more
 brew "asdf"
-# Cryptography and SSL/TLS Toolkit
-brew "openssl@1.1"
-# Interpreted, interactive, object-oriented programming language
-brew "python@3.11"
 # Official Amazon AWS command-line interface
 brew "awscli"
 # Bourne-Again SHell, a UNIX command interpreter
@@ -26,59 +11,30 @@ brew "bash"
 brew "bash-completion@2"
 # Manage your dotfiles across multiple diverse machines, securely
 brew "chezmoi"
-# Docker Credential Helper for Amazon ECR
-brew "docker-credential-helper-ecr"
-# GNU compiler collection
-brew "gcc"
 # GitHub command-line tool
 brew "gh"
 # Distributed revision control system
 brew "git"
-# Smarter Dockerfile linter to validate best practices
-brew "hadolint"
 # Improved top (interactive process viewer)
 brew "htop"
 # Lightweight and flexible command-line JSON processor
 brew "jq"
-# JIT library for the GNU compiler collection
-brew "libgccjit"
 # Package manager for the Lua programming language
 brew "luarocks"
 # Mac App Store command-line interface
 brew "mas"
 # Ambitious Vim-fork focused on extensibility and agility
 brew "neovim"
-# Search tool like grep and The Silver Searcher
-brew "ripgrep"
-# Static analysis and lint tool, for (ba)sh scripts
-brew "shellcheck"
-# Autoformat shell script source code
-brew "shfmt"
+# Encrypt and decrypt secrets using the AWS Key Management Service
+brew "shush"
 # Organize software neatly under a single directory tree (e.g. /usr/local)
 brew "stow"
-# Opinionated Lua code formatter
-brew "stylua"
 # Terminal multiplexer
 brew "tmux"
-# Display directories as trees (with optional color/HTML output)
-brew "tree"
 # Vi 'workalike' with many additional features
 brew "vim"
-# Vim script Language Lint
-brew "vint"
-# Executes a program periodically, showing output fullscreen
-brew "watch"
-# Internet file retriever
-brew "wget"
-# Linter for YAML files
-brew "yamllint"
-# 🔥 Feature-rich interactive Jira command-line
-brew "ankitpokhrel/jira-cli/jira-cli"
-brew "d12frosted/emacs-plus/emacs-plus@29", args: ["with-native-comp"]
 # Authenticate to REA AWS accounts
 brew "reainternal/stable/rea-as"
-# Encrypt and decrypt secrets using AWS KMS
-brew "reainternal/stable/shush"
 # Password manager that keeps all passwords secure behind one password
 cask "1password"
 # Command-line interface for 1Password

--- a/home/.Brewfile_work
+++ b/home/.Brewfile_work
@@ -11,6 +11,8 @@ brew "bash"
 brew "bash-completion@2"
 # Manage your dotfiles across multiple diverse machines, securely
 brew "chezmoi"
+# Diff that understands syntax
+brew "difftastic"
 # Docker Credential Helper for Amazon ECR
 brew "docker-credential-helper-ecr"
 # GitHub command-line tool
@@ -65,10 +67,14 @@ cask "appcleaner"
 cask "arc"
 # Menu bar icon organizer
 cask "bartender"
+# Text, code, and markup editor
+cask "bbedit"
 # Record and process your ideas
 cask "bike"
 # Screen capturing tool
 cask "cleanshot"
+# API documentation browser and code snippet manager
+cask "dash"
 # App to build and share containerized applications and microservices
 cask "docker"
 # Web browser
@@ -83,6 +89,8 @@ cask "font-intel-one-mono"
 cask "font-jetbrains-mono"
 cask "font-roboto-mono"
 cask "font-source-code-pro"
+# GIT client
+cask "fork"
 # Web browser
 cask "google-chrome"
 # Tool to optimize images to a smaller size
@@ -91,6 +99,10 @@ cask "imageoptim"
 cask "insomnia"
 # JetBrains tools manager
 cask "jetbrains-toolbox"
+# Spot and merge differences in text and image files or folders
+cask "kaleidoscope"
+# Open-source keystroke visualizer
+cask "keycastr"
 # Software for Logitech devices
 cask "logi-options-plus"
 # Optimize your webcam, headset, and Logi Dock for video meetings
@@ -103,14 +115,24 @@ cask "microsoft-auto-update"
 cask "microsoft-edge"
 # Office suite
 cask "microsoft-office-businesspro"
+# Tool to create text-based art
+cask "monodraw"
 # Media player based on MPlayer and mplayer2
 cask "mpv"
+# Native code editor
+cask "nova"
 # WebKit based web browser
 cask "orion"
 # Podcast platform
 cask "pocket-casts"
+# GUI client for PostgreSQL databases
+cask "postico"
+# HTTP client that helps testing and describing APIs
+cask "rapidapi"
 # Move and resize windows using keyboard shortcuts or snap areas
 cask "rectangle"
+# Emoji picker optimized for blind people
+cask "rocket"
 # Team communication and collaboration software
 cask "slack"
 # Sound and audio controller
@@ -119,7 +141,9 @@ cask "soundsource"
 cask "zoom"
 mas "1Password for Safari", id: 1569813296
 mas "Bear", id: 1091189122
+mas "Dato", id: 1470584107
 mas "Display Menu", id: 549083868
+mas "Hush", id: 1544743900
 mas "Ivory", id: 6444602274
 mas "Kagi Inc.", id: 1622835804
 mas "Keynote", id: 409183694
@@ -132,4 +156,5 @@ mas "OpenIn", id: 1643649331
 mas "Parcel", id: 639968404
 mas "Subscriptions", id: 1577082754
 mas "Things", id: 904280696
+mas "Velja", id: 1607635845
 mas "Wipr", id: 1320666476

--- a/home/.Brewfile_work
+++ b/home/.Brewfile_work
@@ -17,6 +17,8 @@ brew "docker-credential-helper-ecr"
 brew "gh"
 # Distributed revision control system
 brew "git"
+# Smarter Dockerfile linter to validate best practices
+brew "hadolint"
 # Improved top (interactive process viewer)
 brew "htop"
 # Lightweight and flexible command-line JSON processor
@@ -29,14 +31,24 @@ brew "mas"
 brew "neovim"
 # Search tool like grep and The Silver Searcher
 brew "ripgrep"
+# Static analysis and lint tool, for (ba)sh scripts
+brew "shellcheck"
+# Autoformat shell script source code
+brew "shfmt"
 # Encrypt and decrypt secrets using the AWS Key Management Service
 brew "shush"
 # Organize software neatly under a single directory tree (e.g. /usr/local)
 brew "stow"
+# Opinionated Lua code formatter
+brew "stylua"
 # Terminal multiplexer
 brew "tmux"
 # Vi 'workalike' with many additional features
 brew "vim"
+# Vim script Language Lint
+brew "vint"
+# Linter for YAML files
+brew "yamllint"
 # Authenticate to REA AWS accounts
 brew "reainternal/stable/rea-as"
 # Password manager that keeps all passwords secure behind one password

--- a/home/.chezmoiscripts/run_onchange_before_install-homebrew-packages.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_before_install-homebrew-packages.sh.tmpl
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # .Brewfile hash: {{ include ".Brewfile_work" | sha256sum }}
-brew bundle --global --no-lock
+brew bundle --global --no-lock --verbose

--- a/home/dot_bashrc.d/rea-as.bash.tmpl
+++ b/home/dot_bashrc.d/rea-as.bash.tmpl
@@ -1,2 +1,4 @@
+{{- if eq .profile "work" -}}
 # Enable rea-as completion
 source <(rea-as completion)
+{{- end }}

--- a/home/dot_bashrc.d/rea-aws-funcs.bash.tmpl
+++ b/home/dot_bashrc.d/rea-aws-funcs.bash.tmpl
@@ -1,14 +1,15 @@
+{{- if eq .profile "work" -}}
 # Increase ASG for Adslotinator system.
 rea-aws-adslot-inc() {
   rea-as okta resi-agent-prod-ReadWrite aws autoscaling describe-auto-scaling-groups --filter Name=tag:aws:cloudformation:stack-name,Values=adslotinator |
     jq '.AutoScalingGroups[].AutoScalingGroupName' |
-    xargs rea-as okta resi-agent-prod-ReadWrite aws autoscaling set-desired-capacity   --desired-capacity 1 --auto-scaling-group-name
+    xargs rea-as okta resi-agent-prod-ReadWrite aws autoscaling set-desired-capacity --desired-capacity 1 --auto-scaling-group-name
 }
 
 # Decrease ASG for Adslotinator system.
 rea-aws-adslot-dec() {
   rea-as okta resi-agent-prod-ReadWrite aws autoscaling describe-auto-scaling-groups --filter Name=tag:aws:cloudformation:stack-name,Values=adslotinator |
     jq '.AutoScalingGroups[].AutoScalingGroupName' |
-    xargs rea-as okta resi-agent-prod-ReadWrite aws autoscaling set-desired-capacity   --desired-capacity 0 --auto-scaling-group-name
+    xargs rea-as okta resi-agent-prod-ReadWrite aws autoscaling set-desired-capacity --desired-capacity 0 --auto-scaling-group-name
 }
-
+{{- end }}

--- a/home/dot_profile.d/op.sh
+++ b/home/dot_profile.d/op.sh
@@ -1,0 +1,2 @@
+# source 1password CLI plugins
+. "$XDG_CONFIG_HOME"/op/plugins.sh

--- a/home/dot_profile.d/rea-as.sh.tmpl
+++ b/home/dot_profile.d/rea-as.sh.tmpl
@@ -1,0 +1,6 @@
+{{- if eq .profile "work" -}}
+# Move rea-as cache out of $HOME.
+export REA_AS_CACHE_PATH="$XDG_CACHE_HOME"/rea-as
+# Use Google Authenticator for MFA method.
+export REA_AS_MFA_METHOD=GOOGLE_AUTHENTICATOR
+{{- end }}

--- a/home/private_dot_config/git/config.tmpl
+++ b/home/private_dot_config/git/config.tmpl
@@ -42,6 +42,12 @@
 [credential "https://gist.github.com"]
 	helper =
 	helper = !/usr/local/bin/gh auth git-credential
+[diff]
+	tool = Kaleidoscope
+[difftool]
+	prompt = false
+[difftool "Kaleidoscope"]
+	cmd = ksdiff --partial-changeset --relative-path \"$MERGED\" -- \"$LOCAL\" \"$REMOTE\"
 [fetch]
 	prune = true
 [gpg]
@@ -55,8 +61,13 @@
 [merge]
 	conflictStyle = diff3
 	ff = only
+	tool = Kaleidoscope
 [mergetool]
 	keepBackup = false
+	prompt = false
+[mergetool "Kaleidoscope"]
+	cmd = ksdiff --merge --output \"$MERGED\" --base \"$BASE\" -- \"$LOCAL\" --snapshot \"$REMOTE\" --snapshot
+	trustExitCode = true
 [pull]
 	ff = only
 [rebase]

--- a/home/private_dot_config/nvim/lua/dcp/color.lua
+++ b/home/private_dot_config/nvim/lua/dcp/color.lua
@@ -1,2 +1,2 @@
-vim.opt.termguicolors = true
-vim.cmd([[colorscheme catppuccin-mocha]])
+-- vim.opt.termguicolors = true
+-- vim.cmd([[colorscheme catppuccin-mocha]])

--- a/work/profile.d/rea-as.sh
+++ b/work/profile.d/rea-as.sh
@@ -1,2 +1,0 @@
-# Use Google Authenticator for MFA method.
-export REA_AS_MFA_METHOD=GOOGLE_AUTHENTICATOR


### PR DESCRIPTION
* chore: git ignore 1password CLI config
    
    This allows me to use specific 1Password CLI plugins for this directory,
    mainly using specific GitHub API tokens for work and personal GitHub
    instances.

* feat(sh): setup shell integration for 1Password CLI plugins
    
    This will allow it to work across any shell as long as they use
    ~/.profile configuration.

* feat(brew): remove a bunch of unused applications from work
    
    Some of these will probably get added back in, but trying to pair it
    back and only include what is required.

* feat(bash): migrate rea-as shell completion to chezmoi

* feat(brew): add ripgrep and docker-credential-helper-ecr for work

* feat(sh): move rea-as config into chezmoi
    
    Clean up $HOME and automatically set MFA method to improve my life.

* feat(brew): add linters and formatters to work config

* feat(brew): remove Logseq

* feat(brew): add bike for work apps

* feat(brew): add a bunch of application to trial
    
    Most of these are developer tools.

* feat(nvim): remove theme and termguicolors

* feat(work): update Brewfile

* feat(bash): migtrate work AWS funcs to chezmoi

* chore(chezmoi): use verbose flag when updating packages

* feat(git): use Kaleidoscope for merge and diff tool

