### PR TITLE
docs/update readme

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,8 +1,12 @@
 root = true
 
 [*]
+charset = utf-8
+end_of_line = lf
 indent_style = space
 indent_size = 2
+insert_final_newline = true
+max_line_length = 80
 trim_trailing_whitespace = true
 
 [*.sh]
@@ -17,7 +21,8 @@ indent_size = 4
 [Makefile]
 indent_style = tab
 
-[sh/profile]
+# ~/.profile
+[home/dot_profile]
 shell_variant      = posix # like -ln=posix
 binary_next_line   = true  # like -bn
 switch_case_indent = true  # like -ci

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,8 @@ updates:
   # Enable version updates for npm
   - package-ecosystem: "npm"
     # Look for `package.json` and `lock` files in the `root` directory
-    directory: "/"
+    directory:
+      "/"
       # Check the npm registry for updates every day (weekdays)
     schedule:
       interval: "daily"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,12 +13,12 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "main" ]
+    branches: ["main"]
   schedule:
-    - cron: '32 9 * * 6'
+    - cron: "32 9 * * 6"
 
 jobs:
   analyze:
@@ -32,45 +32,44 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript' ]
+        language: ["javascript"]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Use only 'java' to analyze code written in Java, Kotlin or both
         # Use only 'javascript' to analyze code written in JavaScript, TypeScript or both
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
 
-        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
+          # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+          # queries: security-extended,security-and-quality
 
+      # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v2
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+      #   If the Autobuild fails above, remove it and uncomment the following three lines.
+      #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
 
-    #   If the Autobuild fails above, remove it and uncomment the following three lines.
-    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
+      # - run: |
+      #   echo "Run, Build Application using script"
+      #   ./location_of_script_within_repo/buildscript.sh
 
-    # - run: |
-    #   echo "Run, Build Application using script"
-    #   ./location_of_script_within_repo/buildscript.sh
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
-      with:
-        category: "/language:${{matrix.language}}"
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2
+        with:
+          category: "/language:${{matrix.language}}"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -17,9 +17,11 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Enable auto-merge for Dependabot PRs
         # Only auto-merge minor or patch version updates.
-        if: ${{steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
+        if:
+          ${{steps.metadata.outputs.update-type == 'version-update:semver-minor'
+          || steps.metadata.outputs.update-type ==
+          'version-update:semver-patch'}}
         run: gh pr merge --auto --rebase "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -4,7 +4,7 @@
 #
 # Source repository: https://github.com/actions/dependency-review-action
 # Public documentation: https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review#dependency-review-enforcement
-name: 'Dependency Review'
+name: "Dependency Review"
 on: [pull_request]
 
 permissions:
@@ -14,7 +14,7 @@ jobs:
   dependency-review:
     runs-on: ubuntu-latest
     steps:
-      - name: 'Checkout Repository'
+      - name: "Checkout Repository"
         uses: actions/checkout@v4
-      - name: 'Dependency Review'
+      - name: "Dependency Review"
         uses: actions/dependency-review-action@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,7 @@ on:
       - main
   pull_request:
     branches:
-      - '**'
+      - "**"
 
 jobs:
   lint:

--- a/.nova/Configuration.json
+++ b/.nova/Configuration.json
@@ -1,5 +1,5 @@
 {
-  "editor.default_syntax" : "plain-text",
-  "workspace.color" : 10,
-  "workspace.name" : "Dotfiles"
+  "editor.default_syntax": "plain-text",
+  "workspace.color": 10,
+  "workspace.name": "Dotfiles"
 }

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -2,20 +2,19 @@
 
 Copyright (c) 2019 Dylan Pinn
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,6 @@ XDG_CONFIG_HOME ?= $(HOME)/.config
 XDG_DATA_HOME ?= $(HOME)/.local/share
 XDG_STATE_HOME ?= $(HOME)/.local/state
 
-NAME ?= 'Dylan Pinn'
-
 install: install-dotfiles
 
 check-bash :
@@ -16,10 +14,14 @@ check-sh :
 	sh check/sh.sh
 
 format: format-lua \
+	format-prettier \
 	format-sh
 
 format-lua:
 	sh format/lua.sh
+
+format-prettier:
+	npx prettier --write .
 
 format-sh:
 	sh format/sh.sh

--- a/README.md
+++ b/README.md
@@ -1,37 +1,42 @@
 # Dotfiles
 
-This contains my dotfiles that should work across multiple machines and
-operating systems.
+This contains my dotfiles, configured using `chezmoi`. It currently works for my
+personal and work devices (macOS).
 
 ## Requirements
 
-- `make`
+To setup this on a new machine, the following tools are required:
 
-### macOS
+- `make`, installed by default on modern macOS.
+- [`brew`](https://brew.sh), "The Missing Package Manager for macOS (or Linux)".
+- `chezmoi` (`brew install chezmoi`), "Manage your dotfiles across multiple
+  diverse machines, securely."
 
-- [`brew`](https://brew.sh)
+## Installation / Apply Updates
 
-## Installation
-
-```sh
-make install
-```
+To install the dotfiles or apply changes run `make` with no arguments from the
+project root. This will linters of the files and then run `chezmoi apply -v` to
+apply updates.
 
 ## Configuration
 
-### Per host configuration
-
-You can configure extra Makefile targets and variable overrides by placing them
-in `$XDG_CONFIG_HOME/dotfiles/config` and running `make install-conf`.
+Because `chezmoi` mirrors the destination and uses a unique naming convention
+for hidden and private files it can be a little bit difficult to find the
+configuration. All of the configuration resides in `home` directory.
 
 ### Shell
 
 Bash is my currently my preferred shell, however, most of the configuration
-should be able to work in other shells with minimal work.  The `~/.profile`
+should be able to work in other shells with minimal work. The `~/.profile`
 contains most shell agnostic configuration.
 
 Extra configuration is loaded from the `~/.profile.d` directory, this allows
 setting application or host specific config.
+
+Configuration:
+
+- `~/.profile` -> `./home/dot_profile`
+- `~/.profile.d/` -> `./home/dot_profile.d/`
 
 #### Bash
 
@@ -41,31 +46,60 @@ configuration (`~/.profile`) and bash specific configuration (`~/.bashrc`).
 Extra configuration is loaded from the `~/.bashrc.d` directory, this allows
 setting application or host specific config.
 
+Configuration:
+
+- `~/.bash_profile` -> `./home/dot_bash_profile`
+- `~/.bashrc` -> `./home/dot_bashrc`
+- `~/.bashrc.d/` -> `./home/dot_bashrc.d/`
+
 ### AWS
 
 This just moves the `awscli` configuration out of the `$HOME` directory.
 
 ### Git
 
-This sets some sensible defaults. The configuration is generated using a `m4`
-template and the name and email are added via the `Makefile`.
+This sets some sensible defaults. Per device configuration is handled by
+`chezmoi`. See
+[docs](https://www.chezmoi.io/user-guide/manage-machine-to-machine-differences/)
+for how this is done.
+
+Configuration:
+
+- `~/.config/git/config` -> `./home/private_dot_config/git/config.tmpl`
 
 ### Homebrew
 
-Most applications either CLI or GUI are managed using Homebrew bundle.  The
-`Brewfile` is a manifest of the installed applications.
+Most applications either CLI or GUI are managed using Homebrew bundle. The
+`Brewfile` is a manifest of the installed applications. This is split up into
+separate files for either work or personal profiles. `chezmoi` is able to handle
+this and will re-create the manifest file when needed and apply updates when it
+has changed.
 
-### PostgresSQL
+Configuration:
 
-Sets some sensible defaults for the `psql` CLI.  This moves the CLI
-configuration out of `$HOME`.
+- `~/.Brewfile` -> `./home/dot_Brewfile.tmpl`
+
+### Neovim
+
+I have migrated over to use Neovim as my main editor. The main reason for
+picking this over Vim, is the in-built LSP client and Treesitter support. My
+goal is to use vanilla Neovim as much as possible and only use a plugin when a
+native solution isn't present.
+
+Configuration:
+
+- `~/.config/nvim/` -> `./home/private_dot_config/nvim/`
 
 ### Vim
 
-This is my preferred editor.  The aim is to use as close to vanilla vim as
-possible to ensure compatibility with as many instances of vim as possible.
+The aim is to use as close to vanilla vim as possible to ensure compatibility
+with as many instances of vim as possible.
+
+Configuration:
+
+- `~/.vim/` -> `./home/dot_vim/`
 
 ## Linting and checking
 
 Checks are run on some of the files before installing and linting can be run
-manually with `make lint`.  This is also run in CI using GitHub Actions.
+manually with `make lint`. This is also run in CI using GitHub Actions.

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,4 +1,4 @@
 module.exports = {
-  extends: ['@commitlint/config-conventional'],
+  extends: ["@commitlint/config-conventional"],
   ignores: [(message) => /^Bumps \[(.+)\]\((.+)\)(.*).$/m.test(message)],
-}
+};

--- a/format/sh.sh
+++ b/format/sh.sh
@@ -10,7 +10,7 @@
 
 set -e
 
-set sh/profile
+set home/dot_profile
 
 shfmt -l -w -- "$@"
 

--- a/home/.Brewfile_personal
+++ b/home/.Brewfile_personal
@@ -1,6 +1,5 @@
 tap "enigmaticdb/super-secret-tap"
 tap "homebrew/bundle"
-tap "homebrew/cask"
 tap "homebrew/cask-fonts"
 # Extendable version manager with support for Ruby, Node.js, Erlang & more
 brew "asdf"
@@ -27,7 +26,7 @@ brew "luarocks"
 # Mac App Store command-line interface
 brew "mas"
 # Ambitious Vim-fork focused on extensibility and agility
-brew "neovim"
+brew "neovim", args: ["HEAD"]
 # Search tool like grep and The Silver Searcher
 brew "ripgrep"
 # Static analysis and lint tool, for (ba)sh scripts
@@ -48,6 +47,8 @@ cask "1password-cli"
 cask "appcleaner"
 # Chromium based browser
 cask "arc"
+# Data backup and storage service
+cask "backblaze"
 # Text, code, and markup editor
 cask "bbedit"
 # Record and process your ideas
@@ -60,6 +61,8 @@ cask "calibre"
 cask "cork"
 # API documentation browser and code snippet manager
 cask "dash"
+# Launcher for *Epic Games* games
+cask "epic-games"
 # Web browser
 cask "firefox"
 cask "font-fira-mono"
@@ -85,22 +88,36 @@ cask "font-roboto-mono"
 cask "font-source-code-pro"
 # GIT client
 cask "fork"
+# Game client
+cask "gog-galaxy"
 # Web browser
 cask "google-chrome"
+# Automated organization
+cask "hazel"
 # Software for Logitech devices
 cask "logi-options-plus"
 # Tool to create text-based art
 cask "monodraw"
 # Native code editor
 cask "nova"
+# Calculator and converter application
+cask "numi"
+# Audiobook manager for Audible users
+cask "openaudible"
 # WebKit based web browser
 cask "orion"
 # Workflow application to improve productivity
 cask "pastebot"
 # Move and resize windows using keyboard shortcuts or snap areas
 cask "rectangle"
+# Application to control your PlayStation 4 or PlayStation 5
+cask "sony-ps-remote-play"
+# Video game digital distribution service
+cask "steam"
 mas "1Password for Safari", id: 1569813296
+mas "Dato", id: 1470584107
 mas "Flighty", id: 1358823008
+mas "Hush", id: 1544743900
 mas "Ivory", id: 6444602274
 mas "Kagi Inc.", id: 1622835804
 mas "Keynote", id: 409183694
@@ -110,12 +127,15 @@ mas "Messenger", id: 1480068668
 mas "Microsoft Remote Desktop", id: 1295203466
 mas "Numbers", id: 409203825
 mas "Pages", id: 409201541
+mas "Parcel", id: 639968404
 mas "Photomator", id: 1444636541
 mas "Pixelmator Pro", id: 1289583905
 mas "Play", id: 1596506190
 mas "Save to Reader", id: 1640236961
 mas "Sketch", id: 1667260533
+mas "Subscriptions", id: 1577082754
 mas "Things", id: 904280696
 mas "Wipr", id: 1320666476
+mas "Xcode", id: 497799835
 mas "Yomu", id: 562211012
 mas "‎WhatsApp", id: 310633997

--- a/home/dot_local/bin/executable_git-remove-merged-local.sh
+++ b/home/dot_local/bin/executable_git-remove-merged-local.sh
@@ -17,9 +17,9 @@ update_repo() {
 }
 
 branches() {
-  git branch -vv |
-    grep ': gone]' |
-    awk '{print $1}'
+  git branch -vv \
+    | grep ': gone]' \
+    | awk '{print $1}'
 }
 
 delete_branch() {

--- a/home/dot_local/bin/executable_git-stats-loc.sh
+++ b/home/dot_local/bin/executable_git-stats-loc.sh
@@ -23,11 +23,11 @@ commit_description() {
 }
 
 number_of_lines() {
-  git ls-tree -r "$rev" |
-    grep "$file_pattern" |
-    awk '{ print $3 }' |
-    xargs git show |
-    wc -l
+  git ls-tree -r "$rev" \
+    | grep "$file_pattern" \
+    | awk '{ print $3 }' \
+    | xargs git show \
+    | wc -l
 }
 
 main

--- a/home/dot_profile.d/op.sh
+++ b/home/dot_profile.d/op.sh
@@ -1,2 +1,0 @@
-# source 1password CLI plugins
-. "$XDG_CONFIG_HOME"/op/plugins.sh

--- a/home/dot_profile.d/visual.sh
+++ b/home/dot_profile.d/visual.sh
@@ -1,3 +1,3 @@
 # For visual editor use vim.
-VISUAL='vim'
+VISUAL='nvim'
 export VISUAL

--- a/home/dot_zshrc
+++ b/home/dot_zshrc
@@ -1,2 +1,0 @@
-# Integrate 1Password CLI plugins with zsh.
-source ~/.config/op/plugins.sh

--- a/home/private_dot_config/nvim/lua/dcp/color.lua
+++ b/home/private_dot_config/nvim/lua/dcp/color.lua
@@ -1,2 +1,0 @@
-vim.cmd([[colorscheme morning]])
--- vim.cmd([[colorscheme evening]])

--- a/home/private_dot_config/nvim/lua/dcp/packages.lua
+++ b/home/private_dot_config/nvim/lua/dcp/packages.lua
@@ -8,7 +8,8 @@ return require("paq")({
 
   -- Treesitter configuration; this is required to integrate Treesitter.
   {
-    "nvim-treesitter/nvim-treesitter", build = ':TSUpdate'
+    "nvim-treesitter/nvim-treesitter",
+    build = ":TSUpdate",
   },
 
   -- Enhance (n)vim.

--- a/home/private_dot_config/tmux/README.md
+++ b/home/private_dot_config/tmux/README.md
@@ -1,9 +1,9 @@
 # Tmux Configuration
 
-Currently my tmux configuration is pretty sparse.  The main change is to the
-prefix keybinding from `C-b` to `C-a`.  This matches the original keybinding
-that was present in `screen` and feels more natural to me rather than reaching
-for `C-b`.
+Currently my tmux configuration is pretty sparse. The main change is to the
+prefix keybinding from `C-b` to `C-a`. This matches the original keybinding that
+was present in `screen` and feels more natural to me rather than reaching for
+`C-b`.
 
 Other changes are quality of life improvements for working with (neo)vim inside
 tmux.


### PR DESCRIPTION
* docs: update README
    
    Update README to include information about chezmoi and how it is being used to
    handle dotfile installation and multi device configuration.

* feat(editorconfig): match prettier defaults
    
    Taken from https://prettier.io/docs/en/configuration.html#editorconfig.

* feat(brew): update personal Homebrew config
    
    Add PS remote play, Backblaze, Steam and other game launchers.

* feat(format): add prettier format make target
    
    Run prettier over the codebase via `make format-prettier` or `make format`.

* feat(op): remove 1password CLI configuration
    
    Going to use the native OS auth for managing access to GitHub CLI. If setup
    other plugins, then this will need to be re-added.

* feat(nvim): set as default and use default colorscheme

* style: format all files using `make format`

