### PR TITLE
fix: force link homebrew m4 to replace missing binary

### DIFF
--- a/homebrew/personal.Brewfile
+++ b/homebrew/personal.Brewfile
@@ -20,6 +20,8 @@ brew "jq"
 brew "lua-language-server"
 # Tool for linting and static analysis of Lua code
 brew "luacheck"
+# Macro processing language
+brew "m4", link: true
 # Mac App Store command-line interface
 brew "mas"
 # Polyglot runtime manager (asdf rust clone)


### PR DESCRIPTION
m4 is missing from 15.3 Apple Command Line Tools. This should be fixed
in the future and this change can be removed.
