### PR TITLE
nvim: format Lua files using Conform.nvim

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "nvim/pack/bundle/start/copilot.vim"]
 	path = nvim/pack/bundle/start/copilot.vim
 	url = https://github.com/github/copilot.vim.git
+[submodule "nvim/pack/bundle/start/conform.nvim"]
+	path = nvim/pack/bundle/start/conform.nvim
+	url = https://github.com/stevearc/conform.nvim.git

--- a/nvim/after/ftplugin/lua.lua
+++ b/nvim/after/ftplugin/lua.lua
@@ -1,10 +1,5 @@
 -- Tabs should have 4 space width.
 vim.opt_local.tabstop = 4
 
--- Use stylua as formatter if it is available.
-if vim.fn.executable("stylua") == 1 then
-	vim.opt_local.formatprg = "stylua --stdin-filepath % --search-parent-directories -"
-end
-
 -- Use luacheck as compiler for sh files.
 vim.cmd([[compiler luacheck]])

--- a/nvim/after/plugin/conform.lua
+++ b/nvim/after/plugin/conform.lua
@@ -1,0 +1,7 @@
+local options = {
+	formatters_by_ft = {
+		lua = { "stylua" },
+	},
+}
+
+require("conform").setup(options)

--- a/nvim/after/plugin/lsp.lua
+++ b/nvim/after/plugin/lsp.lua
@@ -65,8 +65,5 @@ vim.api.nvim_create_autocmd("LspAttach", {
 		vim.keymap.set("n", "<localleader>rn", vim.lsp.buf.rename, opts)
 		vim.keymap.set({ "n", "v" }, "<localleader>ca", vim.lsp.buf.code_action, opts)
 		vim.keymap.set("n", "gr", vim.lsp.buf.references, opts)
-		vim.keymap.set("n", "<localleader>f", function()
-			vim.lsp.buf.format({ async = true })
-		end, opts)
 	end,
 })

--- a/nvim/lua/dcp/keymaps.lua
+++ b/nvim/lua/dcp/keymaps.lua
@@ -22,6 +22,13 @@
 vim.g.mapleader = "\\"
 vim.g.maplocalleader = " "
 
+-- Leader,a series acts on the whole file.
+--
+-- Leader,ai indents the whole file.
+vim.keymap.set("n", "<Leader>ai", "mzgg=G`z")
+-- Leader,af formats the whole file.
+vim.keymap.set("n", "<Leader>af", "mzgggqG`z")
+
 -- Leader,b list all open buffers.
 vim.keymap.set("n", "<Leader>b", ":buffer <C-d>")
 


### PR DESCRIPTION
Use conform.nvim to run formatters for Lua files.

This would then be setup to run Prettier over a range of other filetypes, same with `shfmt`.
