### PR TITLE
fix: add missing formatexpr for conform

### DIFF
--- a/nvim/after/plugin/conform.lua
+++ b/nvim/after/plugin/conform.lua
@@ -5,3 +5,7 @@ local options = {
 }
 
 require("conform").setup(options)
+
+-- This should be okay to set globally, as will default back to the LSP
+-- formatexpr if present and then to nothing.
+vim.o.formatexpr = "v:lua.require'conform'.formatexpr()"


### PR DESCRIPTION
This was working previously as the LSP client defaults to using itself
when not set.
