### PR TITLE
add git hooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,7 @@ install-git: git/config
 	mkdir -p -- $(XDG_CONFIG_HOME)/git
 	cp -p -- git/config $(XDG_CONFIG_HOME)/git/config
 	cp -p -- git/ignore $(XDG_CONFIG_HOME)/git/ignore
+	cp -pR -- git/hooks/ $(XDG_CONFIG_HOME)/git/hooks/
 
 install-mise: install-bash
 	cp -p -- mise/bashrc.d/* $(HOME)/.bashrc.d/

--- a/git/config.m4
+++ b/git/config.m4
@@ -31,6 +31,8 @@
 	st = status
 [commit]
 	gpgsign = true
+[core]
+	hooksPath = ~/.config/git/hooks
 [gpg]
 	format = ssh
 [gpg "ssh"]

--- a/git/hooks/commit-msg
+++ b/git/hooks/commit-msg
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Defines Git commit message functionality.
+
+set -o nounset
+set -o errexit
+set -o pipefail
+IFS=$'\n\t'
+
+source "$HOME/.config/git/hooks/extensions/support.sh"
+source "$HOME/.config/git/hooks/extensions/git.sh"
+
+git_lint_check

--- a/git/hooks/extensions/git.sh
+++ b/git/hooks/extensions/git.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# Label: Git Lint Check
+# Description: Enforce consistent Git commits.
+git_lint_check() {
+  if _check_gem_dependencies "git-lint"; then
+    git-lint --hook "${BASH_ARGV[0]}"
+  fi
+}
+export -f git_lint_check

--- a/git/hooks/extensions/support.sh
+++ b/git/hooks/extensions/support.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# Label: Check Gem Dependencies
+# Description: Check Gemfile/gemspec dependencies for specified gem.
+# Parameters: $1 (required): The gem name.
+_check_gem_dependencies() {
+  local gem="$1"
+  rg "(add.*dependency \"$gem\"|add.*dependency '$gem'|gem \"$gem\"|gem '$gem')" --max-depth 1 . > /dev/null
+}
+export -f _check_gem_dependencies
+

--- a/lint/sh.sh
+++ b/lint/sh.sh
@@ -9,4 +9,12 @@ shellcheck --shell=sh sh/profile
 find . \
     -name "*.sh" \
     -not -path "./nvim/pack/bundle/*" \
+    -not -path "*/profile.d/*" \
+    -exec shellcheck {} +
+
+# Scripts in the `profile.d` directory are sourced by the shell, so they don't
+# have a shebang. We need to tell shellcheck to treat them as POSIX shell.
+find . \
+    -name "*/profile.d/*.sh" \
+    -not -path "./nvim/pack/bundle/*" \
     -exec shellcheck --shell=sh {} +


### PR DESCRIPTION
- **Add git hooks to check commits using git-lint**
  This uses git-lint (https://alchemists.io/projects/git-lint) to ensure
  that commit messages are correct.
  
  More work is needed in the next commit to tell git to use this directory
  for all git hooks.
  

- **Install git hooks directory with install-git target**
  

- **chore: use script shebang for shellcheck unless profile config**
  These don't have a shebang as aren't scripts that are executed so these
  are explicitly told by shellcheck to use shell=sh.
  