### PR TITLE
fix(git): quote email when passed to file before templating

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ format-sh:
 
 git/config: git/config.m4
 	m4 \
-		--define=NAME=$(NAME) \
+		--define=NAME="$(NAME)" \
 		--define=EMAIL="$(EMAIL)" \
 		--define=SIGNING_KEY="$(SIGNING_KEY)" \
 		git/config.m4 > $@


### PR DESCRIPTION
This was causing issues if it wasn't quoted correctly.