### PR TITLE
feat(mise): configure default npm global packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,8 @@ install-jj: install-git
 
 install-mise: install-bash
 	cp -p -- mise/bashrc.d/* $(HOME)/.bashrc.d/
+	cp -p -- mise/profile.d/* $(HOME)/.profile.d/
+	cp -p -- mise/npm-default-packages $(XDG_CONFIG_HOME)/mise/npm-default-packages
 
 install-npm:
 	mkdir -p -- $(XDG_CONFIG_HOME)/npm

--- a/mise/npm-default-packages
+++ b/mise/npm-default-packages
@@ -1,0 +1,3 @@
+@github/copilot
+typescript
+typescript-language-server

--- a/mise/profile.d/default-npm-packages.sh
+++ b/mise/profile.d/default-npm-packages.sh
@@ -1,0 +1,4 @@
+# shellcheck shell=sh
+
+# Set a non-default location for default npm global packages.
+export MISE_NODE_DEFAULT_PACKAGES_FILE="$XDG_CONFIG_HOME/mise/npm-default-packages"


### PR DESCRIPTION
Adds support for default global npm packages via mise.

Changes:

  - Add `mise/npm-default-packages` listing `@github/copilot`, `typescript`, `typescript-language-server`.
  - Add profile script exporting `MISE_NODE_DEFAULT_PACKAGES_FILE` to XDG config location.
  - Update `Makefile` `install-mise` target to copy profile.d scripts and npm-default-packages file.

Result: When installing Node with `mise`, these packages are auto-installed globally.